### PR TITLE
Report command parse error as such

### DIFF
--- a/lib/Purescript/Ide.hs
+++ b/lib/Purescript/Ide.hs
@@ -202,7 +202,7 @@ data Command =
     deriving(Show, Eq)
 
 parseCommand :: Text -> Either ParseError Command
-parseCommand = parse parseCommand' ""
+parseCommand text = parse parseCommand' ("Failed to parse command '" ++ T.unpack text ++ "'") text
 
 parseCommand' :: Parser Command
 parseCommand' =


### PR DESCRIPTION
Make psc-ide actually say there's been a parse error instead of just printing a source position.