### PR TITLE
Deduplicate aeson dependency

### DIFF
--- a/psc-ide.cabal
+++ b/psc-ide.cabal
@@ -23,7 +23,6 @@ library
   build-depends:         aeson
                        , base >= 4.7 && < 5
                        , containers
-                       , aeson
                        , mtl
                        , parsec
                        , text
@@ -52,7 +51,6 @@ executable psc-ide-server
                      , base >= 4.7 && < 5
                      , directory
                      , filepath
-                     , aeson
                      , lens
                      , lens-aeson
                      , mtl


### PR DESCRIPTION
I don't think it hurts, but I noticed that aeson is specified twice. :)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/kritzcreek/psc-ide/29)
<!-- Reviewable:end -->
