### PR TITLE
Add some type synonyms as documentation

### DIFF
--- a/lib/PureScript/Ide/Command.hs
+++ b/lib/PureScript/Ide/Command.hs
@@ -6,6 +6,7 @@ import           Data.Text        (Text)
 import qualified Data.Text        as T
 import           Text.Parsec
 import           Text.Parsec.Text
+import           PureScript.Ide.Externs (ModuleIdent, DeclIdent)
 
 data Level
     = File
@@ -14,10 +15,10 @@ data Level
     deriving (Show,Eq)
 
 data Command
-    = TypeLookup Text
+    = TypeLookup DeclIdent
     | Complete Text Level
-    | Load Text
-    | LoadDependencies Text
+    | Load ModuleIdent
+    | LoadDependencies ModuleIdent
     | Print
     | Cwd
     | Quit

--- a/lib/PureScript/Ide/Externs.hs
+++ b/lib/PureScript/Ide/Externs.hs
@@ -5,6 +5,9 @@ module PureScript.Ide.Externs
   (
     ExternParse,
     ExternDecl(..),
+    ModuleIdent,
+    DeclIdent,
+    Type,
     Fixity(..),
     readExternFile,
     parseExternDecl,
@@ -22,17 +25,21 @@ type ExternParse = Either ParseError [ExternDecl]
 
 data Fixity = Infix | Infixl | Infixr deriving(Show, Eq)
 
+type ModuleIdent = Text
+type DeclIdent   = Text
+type Type        = Text
+
 data ExternDecl
-    = FunctionDecl { functionName :: Text
-                   , functionType :: Text}
+    = FunctionDecl { functionName :: DeclIdent
+                   , functionType :: Type}
     | FixityDeclaration Fixity
                         Int
-                        Text
-    | Dependency { dependencyModule :: Text
+                        DeclIdent
+    | Dependency { dependencyModule :: DeclIdent
                  , dependencyNames  :: Text}
-    | ModuleDecl Text
-                 [Text]
-    | DataDecl Text
+    | ModuleDecl ModuleIdent
+                 [DeclIdent]
+    | DataDecl DeclIdent
                Text
     deriving (Show,Eq)
 
@@ -40,7 +47,7 @@ data ExternDecl
 readExternFile :: FilePath -> IO ExternParse
 readExternFile fp = readExtern <$> (T.lines <$> T.readFile fp)
 
-readExtern:: [Text] -> ExternParse
+readExtern :: [Text] -> ExternParse
 readExtern strs = mapM (parse parseExternDecl "") clean
   where
     clean = removeComments strs

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -12,6 +12,7 @@ import           Network.Socket           hiding (PortNumber, accept, sClose)
 import           Options.Applicative
 import           PureScript.Ide
 import           PureScript.Ide.Command
+import           PureScript.Ide.Externs   (ModuleIdent)
 import           System.Directory
 import           System.Exit
 import           System.FilePath
@@ -96,7 +97,7 @@ handleCommand Print = T.intercalate ", " <$> printModules
 handleCommand Cwd = liftIO (T.pack <$> getCurrentDirectory)
 handleCommand Quit = liftIO exitSuccess
 
-loadModule :: T.Text -> PscIde T.Text
+loadModule :: ModuleIdent -> PscIde T.Text
 loadModule mn = do
     path <- liftIO $ filePathFromModule mn
     case path of
@@ -105,7 +106,7 @@ loadModule mn = do
         Left err -> return err
 
 
-filePathFromModule :: T.Text -> IO (Either T.Text FilePath)
+filePathFromModule :: ModuleIdent -> IO (Either T.Text FilePath)
 filePathFromModule moduleName = do
     cwd <- getCurrentDirectory
     let path = cwd </> "output" </> T.unpack moduleName </> "externs.purs"


### PR DESCRIPTION
My suggestion would be to get this in for now and improve where/when needed. (Newtypes, better names, etc.) At least this distinguishes some of the `Text` and `T.Text` types to the reader and to grep (or your favourite editor's search function).

Here's some inspiration for type synonym I cobbled together from psc and psc-publish: https://gist.github.com/epost/8c8b9cdff3c0542a6471, which may help explain why I did *not* opt for some of the alternatives we discussed, like `ModuleName`; they're quite different than what we're using.