### PR TITLE
Distinguish errors from success results (first stab)

### DIFF
--- a/lib/PureScript/Ide.hs
+++ b/lib/PureScript/Ide.hs
@@ -11,9 +11,13 @@ module PureScript.Ide
     unsafeStateFromDecls,
     PscIde,
     PscState(..),
+    first,
+    maybeToEither,
+    textResult,
   ) where
 
 import           Control.Monad
+import           Control.Monad.Except
 import           Control.Monad.State.Lazy (StateT (..), get, modify)
 import           Control.Monad.Trans
 import           Data.Foldable
@@ -25,6 +29,8 @@ import qualified Data.Text                as T
 import           PureScript.Ide.Command
 import           PureScript.Ide.Externs
 import           PureScript.Ide.Pursuit
+import           PureScript.Ide.Err
+import           Text.Parsec.Error (ParseError(..))
 
 type Module = (ModuleIdent, [ExternDecl])
 
@@ -109,3 +115,11 @@ unsafeStateFromDecls = PscState . M.fromList . fmap unsafeModuleFromDecls
 
 printModules :: PscIde [ModuleIdent]
 printModules = M.keys . pscStateModules <$> get
+
+-- | Taken from Data.Either.Utils
+maybeToEither :: MonadError e m =>
+                 e                      -- ^ (Left e) will be returned if the Maybe value is Nothing
+              -> Maybe a                -- ^ (Right a) will be returned if this is (Just a)
+              -> m a
+maybeToEither errorval Nothing = throwError errorval
+maybeToEither _ (Just normalval) = return normalval

--- a/lib/PureScript/Ide/Command.hs
+++ b/lib/PureScript/Ide/Command.hs
@@ -7,6 +7,7 @@ import qualified Data.Text        as T
 import           Text.Parsec
 import           Text.Parsec.Text
 import           PureScript.Ide.Externs (ModuleIdent, DeclIdent)
+import           PureScript.Ide.Err
 
 data Level
     = File
@@ -24,8 +25,9 @@ data Command
     | Quit
     deriving (Show,Eq)
 
-parseCommand :: Text -> Either ParseError Command
-parseCommand = parse parseCommand' ""
+parseCommand :: T.Text -> Either Err Command
+parseCommand t = first (\parseErr -> ParseErr parseErr "Parse error")
+                       (parse parseCommand' "" t)
 
 parseCommand' :: Parser Command
 parseCommand' =

--- a/lib/PureScript/Ide/Err.hs
+++ b/lib/PureScript/Ide/Err.hs
@@ -1,0 +1,52 @@
+{-# OPTIONS_GHC -fno-warn-unused-do-bind #-}
+module PureScript.Ide.Err
+  (
+    ErrMsg,
+    Err (..),
+    Ident,
+    first,
+    textErr,
+    textResult,
+    textResultNewFormat,
+  ) where
+
+import           Data.Monoid
+import           Data.Text                (Text, pack, unpack)
+import qualified Text.Parsec.Error        as P
+import           PureScript.Ide.Externs   (ModuleIdent, DeclIdent)
+
+type ErrMsg = String
+
+data Err
+    = GeneralErr ErrMsg
+    | NotFound Ident
+    | ModuleNotFound ModuleIdent
+    | ParseErr P.ParseError ErrMsg
+    deriving (Show, Eq)
+
+type Ident = Text
+
+textErr :: Err -> Text
+textErr (GeneralErr msg)             = pack msg
+textErr (NotFound ident)             = "Symbol '" <> ident <> "' not found."
+textErr (ModuleNotFound ident)       = "Module '" <> ident <> "' not found."
+textErr (ParseErr parseErr msg)      = pack $ msg <> ": " <> show (escape parseErr)
+  where
+    -- escape newlines and other special chars so we can send the error over the socket as a single line
+    escape :: P.ParseError -> String
+    escape = show
+
+-- | This allows us to distinguish errors from success results in the output.
+textResultNewFormat :: Either Err Text -> Text
+textResultNewFormat (Right response) = pack $ "ok: "    <> unpack response
+textResultNewFormat (Left err)       = pack "error: " <> textErr err
+
+-- | Don't break compatibility for now
+textResult :: Either Err Text -> Text
+textResult (Right response) = response
+textResult (Left err)       = textErr err
+
+-- | Specialized version of `first` from `Data.Bifunctors`
+first :: (a -> b) -> Either a r -> Either b r
+first f (Left x)   = Left (f x)
+first _ (Right r2) = Right r2

--- a/psc-ide.cabal
+++ b/psc-ide.cabal
@@ -17,6 +17,7 @@ library
   exposed-modules:       PureScript.Ide
                        , PureScript.Ide.Command
                        , PureScript.Ide.Externs
+                       , PureScript.Ide.Err
                        , PureScript.Ide.CodecJSON
                        , PureScript.Ide.Pursuit
   default-language:      Haskell2010


### PR DESCRIPTION
I'm sure there are a few points to discuss, esp. wrt to module factoring, but here's a first approximation. (I think having a `Types.hs` module might be nice, for example.)

This change doesn't affect `psc-ide-server`'s output yet, except maybe the wording of some error messages; I deliberately put the new output in `textResultNewFormat`, and I'm calling `textResult` (the old format) instead for now so as not to break things.

I think working the `Either` bits (possibly type aliased into something like `Result a`) further into the code could also help to clean things up considerably; we could get rid of the constant `case ... of` unpacking of `Maybe` and `Either` values. Perhaps throw in an `EitherT` or something.