### PR TITLE
handle reexports for completion search

### DIFF
--- a/lib/PureScript/Ide.hs
+++ b/lib/PureScript/Ide.hs
@@ -5,7 +5,7 @@ import           Control.Monad.Except
 import           Control.Monad.State.Lazy (StateT (..), get, modify)
 import           Control.Monad.Trans.Either
 import qualified Data.Map.Lazy            as M
-import           Data.Maybe               (mapMaybe)
+import           Data.Maybe               (mapMaybe, catMaybes)
 import           Data.Monoid
 import qualified Data.Text  as T
 import           PureScript.Ide.Completion
@@ -14,6 +14,7 @@ import           PureScript.Ide.Pursuit
 import           PureScript.Ide.Error
 import           PureScript.Ide.Types
 import           PureScript.Ide.SourceFile
+import           PureScript.Ide.Reexports
 import           System.FilePath
 import           System.Directory
 
@@ -28,10 +29,33 @@ getAllDecls = concat <$> getPscIdeState
 getAllModules :: PscIde [Module]
 getAllModules = M.toList <$> getPscIdeState
 
+getAllModulesWithReexports :: PscIde [Module]
+getAllModulesWithReexports = do
+  mis <- M.keys <$> getPscIdeState
+  ms  <- traverse getModuleWithReexports mis
+  return (catMaybes ms)
+
 getModule :: ModuleIdent -> PscIde (Maybe Module)
 getModule m = do
   modules <- getPscIdeState
   return ((m,) <$> M.lookup m modules)
+
+getModuleWithReexports :: ModuleIdent -> PscIde (Maybe Module)
+getModuleWithReexports mi = do
+  m <- getModule mi
+  db <- getPscIdeState
+  case m of
+    Just m' -> do
+      resolved <- resolveReexports m' db
+      return (Just resolved)
+    Nothing -> return Nothing
+  where
+    resolveReexports m db = do
+      let replaced = replaceReexports m db
+      liftIO $ print (getReexports replaced)
+      if null . getReexports $ replaced
+        then return replaced
+        else resolveReexports replaced db
 
 insertModule :: Module -> PscIde ()
 insertModule (name, decls) =
@@ -39,11 +63,11 @@ insertModule (name, decls) =
 
 findCompletions :: [Filter] -> Matcher -> PscIde Success
 findCompletions filters matcher =
-  CompletionResult <$> getCompletions filters matcher <$> getAllModules
+  CompletionResult <$> getCompletions filters matcher <$> getAllModulesWithReexports
 
 findType :: DeclIdent -> [Filter] -> PscIde Success
 findType search filters =
-  CompletionResult <$> getExactMatches search filters <$> getAllModules
+  CompletionResult <$> getExactMatches search filters <$> getAllModulesWithReexports
 
 findPursuitCompletions :: PursuitQuery -> PscIde Success
 findPursuitCompletions (PursuitQuery q) =

--- a/lib/PureScript/Ide/Externs.hs
+++ b/lib/PureScript/Ide/Externs.hs
@@ -18,6 +18,7 @@ import           Data.Maybe                  (mapMaybe)
 import qualified Data.Text                   as T
 import qualified Data.Text.IO                as T
 import qualified Language.PureScript.Externs as PE
+import qualified Language.PureScript.AST.Declarations as D
 import qualified Language.PureScript.Names   as N
 import qualified Language.PureScript.Pretty  as PP
 import           PureScript.Ide.CodecJSON
@@ -41,16 +42,21 @@ identToText :: N.Ident -> T.Text
 identToText  = T.pack . N.runIdent
 
 convertExterns :: PE.ExternsFile -> Module
-convertExterns ef = (moduleName, importDecls ++ otherDecls)
+convertExterns ef = (moduleName, exportDecls ++ importDecls ++ otherDecls)
   where
     moduleName = moduleNameToText (PE.efModuleName ef)
     importDecls = convertImport <$> PE.efImports ef
+    exportDecls = mapMaybe convertExport (PE.efExports ef)
     -- Ignoring operator fixities for now since we're not using them
     -- operatorDecls = convertOperator <$> PE.efFixities ef
     otherDecls = mapMaybe convertDecl (PE.efDeclarations ef)
 
 convertImport :: PE.ExternsImport -> ExternDecl
 convertImport ei = Dependency (moduleNameToText (PE.eiModule ei)) []
+
+convertExport :: D.DeclarationRef -> Maybe ExternDecl
+convertExport (D.ModuleRef mn) = Just (Export (T.pack $ N.runModuleName mn))
+convertExport _ = Nothing
 
 convertDecl :: PE.ExternsDeclaration -> Maybe ExternDecl
 convertDecl (PE.EDType{..}) = Just $

--- a/lib/PureScript/Ide/Reexports.hs
+++ b/lib/PureScript/Ide/Reexports.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE TupleSections #-}
+module PureScript.Ide.Reexports where
+
+import Data.Maybe
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.List (union)
+import PureScript.Ide.Types
+
+getReexports :: Module -> [ExternDecl]
+getReexports (mn, decls)= mapMaybe getExport decls
+  where getExport e@(Export mn')
+          | mn /= mn' = Just e
+          | otherwise = Nothing
+        getExport _ = Nothing
+
+replaceReexport :: ExternDecl -> Module -> Module -> Module
+replaceReexport e@(Export _) (m, decls) (_, newDecls) =
+  (m, filter (/= e) decls `union` newDecls)
+replaceReexport _ _ _ = error "Should only get Exports here."
+
+emptyModule :: Module
+emptyModule = ("Empty", [])
+
+isExport :: ExternDecl -> Bool
+isExport (Export _) = True
+isExport _ = False
+
+removeExportDecls :: Module -> Module
+removeExportDecls = fmap (filter (not . isExport))
+
+replaceReexports :: Module -> Map ModuleIdent [ExternDecl] -> Module
+replaceReexports m db = result
+  where reexports = getReexports m
+        result = foldl go (removeExportDecls m) reexports
+
+        go :: Module -> ExternDecl -> Module
+        go m' re@(Export name) = replaceReexport re m' (getModule name)
+
+        getModule :: ModuleIdent -> Module
+        getModule name = fromMaybe emptyModule $ (name , ) <$> Map.lookup name db

--- a/lib/PureScript/Ide/Types.hs
+++ b/lib/PureScript/Ide/Types.hs
@@ -16,7 +16,7 @@ type ModuleIdent = Text
 type DeclIdent   = Text
 type Type        = Text
 
-data Fixity = Infix | Infixl | Infixr deriving(Show, Eq)
+data Fixity = Infix | Infixl | Infixr deriving(Show, Eq, Ord)
 
 data ExternDecl
     = FunctionDecl { functionName :: DeclIdent
@@ -30,7 +30,8 @@ data ExternDecl
                  [DeclIdent]
     | DataDecl DeclIdent
                Text
-    deriving (Show,Eq)
+    | Export ModuleIdent
+    deriving (Show,Eq,Ord)
 
 instance ToJSON ExternDecl where
   toJSON (FunctionDecl n t)        = object ["name" .= n, "type" .= t]
@@ -40,6 +41,7 @@ instance ToJSON ExternDecl where
   toJSON (FixityDeclaration f p n) = object ["name" .= n
                                             , "fixity" .= show f
                                             , "precedence" .= p]
+  toJSON (Export _) = object []
 
 type Module = (ModuleIdent, [ExternDecl])
 

--- a/psc-ide.cabal
+++ b/psc-ide.cabal
@@ -25,6 +25,7 @@ library
                        , PureScript.Ide.Filter
                        , PureScript.Ide.Types
                        , PureScript.Ide.SourceFile
+                       , PureScript.Ide.Reexports
   default-language:      Haskell2010
   build-depends:         aeson
                        , base >= 4.7 && < 5
@@ -76,8 +77,10 @@ test-suite spec
   hs-source-dirs:      test
   default-language:    Haskell2010
   main-is:             Spec.hs
-  other-modules:       PureScript.Ide.FilterSpec
+  other-modules:       PureScript.IdeSpec
+                     , PureScript.Ide.FilterSpec
                      , PureScript.Ide.MatcherSpec
+                     , PureScript.Ide.ReexportsSpec
   build-depends:       base    >= 4.7 && < 5
                      , psc-ide
                      , mtl

--- a/test/PureScript/Ide/ReexportsSpec.hs
+++ b/test/PureScript/Ide/ReexportsSpec.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE OverloadedStrings #-}
+module PureScript.Ide.ReexportsSpec where
+
+import Test.Hspec
+import PureScript.Ide.Reexports
+import PureScript.Ide.Types
+import Data.List (sort)
+import qualified Data.Map as Map
+import Control.Exception (evaluate)
+
+decl1 = FunctionDecl "filter" "asdasd"
+decl2 = DataDecl "Tree" "* -> *"
+decl3 = DataDecl "TreeAsd" "* -> *"
+
+circularModule = ("Circular", [Export "Circular"])
+
+module1 :: Module
+module1 = ("Module1", [Export "Module2", Export "Module3", decl1])
+
+module2 :: Module
+module2 = ("Module2", [decl2])
+
+module3 :: Module
+module3 = ("Module3", [decl3])
+
+result :: Module
+result = ("Module1", [decl1, decl2, Export "Module3"])
+
+db = Map.fromList [module1, module2, module3]
+
+shouldBeEqualSorted :: Module -> Module -> Expectation
+shouldBeEqualSorted (n1, d1) (n2, d2) = (n1, sort d1) `shouldBe` (n2, sort d2)
+
+spec = do
+  describe "Reexports" $ do
+    it "finds all reexports" $
+      getReexports module1 `shouldBe` [Export "Module2", Export "Module3"]
+
+    it "replaces a reexport with another module" $
+      replaceReexport (Export "Module2") module1 module2 `shouldBeEqualSorted` result
+
+    it "adds another module even if there is no export statement" $
+      replaceReexport (Export "Module2") ("Module1", [decl1, Export "Module3"]) module2
+      `shouldBeEqualSorted` result
+
+    it "only adds a declaration once" $
+      let replaced = replaceReexport (Export "Module2") module1 module2
+      in replaceReexport (Export "Module2") replaced module2  `shouldBeEqualSorted` result
+
+    it "should error when given a non-Export to replace" $
+      evaluate (replaceReexport decl1 module1 module2) `shouldThrow` errorCall "Should only get Exports here."
+    it "replaces all Exports with their corresponding declarations" $
+      replaceReexports module1 db `shouldBe` ("Module1", [decl1, decl2, decl3])
+
+    it "does not list itself as a reexport" $
+      getReexports circularModule `shouldBe` []


### PR DESCRIPTION
This does not handle resolving reexports as dependencies when loading modules into psc-ide (yet)