### PR TITLE
Updated for 0.8.0.0

### DIFF
--- a/psc-ide.cabal
+++ b/psc-ide.cabal
@@ -42,7 +42,7 @@ library
                        , monad-logger
                        , mtl
                        , parsec
-                       , purescript
+                       , purescript >= 0.8.0.0
                        , regex-tdfa
                        , stm
                        , text

--- a/src/PureScript/Ide/SourceFile.hs
+++ b/src/PureScript/Ide/SourceFile.hs
@@ -40,18 +40,18 @@ getImportsForFile fp = do
   module' <- parseModuleFromFile fp
   let imports = getImports <$> module'
   return (fmap (mkModuleImport . unwrapPositionedImport) <$> imports)
-  where mkModuleImport (D.ImportDeclaration mn importType' qualifier) =
+  where mkModuleImport (D.ImportDeclaration mn importType' qualifier _) =
           ModuleImport
             (T.pack (N.runModuleName mn))
             importType'
             (T.pack . N.runModuleName <$> qualifier)
         mkModuleImport _ = error "Shouldn't have gotten anything but Imports here"
-        unwrapPositionedImport (D.ImportDeclaration mn importType' qualifier) =
-          D.ImportDeclaration mn (unwrapImportType importType') qualifier
+        unwrapPositionedImport (D.ImportDeclaration mn importType' qualifier b) =
+          D.ImportDeclaration mn (unwrapImportType importType') qualifier b
         unwrapPositionedImport x = x
         unwrapImportType (D.Explicit decls) = D.Explicit (map unwrapPositionedRef decls)
         unwrapImportType (D.Hiding decls)   = D.Hiding (map unwrapPositionedRef decls)
-        unwrapImportType D.Implicit         = D.Implicit
+        unwrapImportType (D.Implicit b)     = D.Implicit b
 
 getPositionedImports :: D.Module -> [D.Declaration]
 getPositionedImports (D.Module _ _ _ declarations _) =

--- a/src/PureScript/Ide/Types.hs
+++ b/src/PureScript/Ide/Types.hs
@@ -87,7 +87,7 @@ instance Eq ModuleImport where
                && importQualifier mi1 == importQualifier mi2
 
 instance ToJSON ModuleImport where
-  toJSON (ModuleImport mn D.Implicit qualifier) =
+  toJSON (ModuleImport mn (D.Implicit _) qualifier) =
     object $  ["module" .= mn
               , "importType" .= ("implicit" :: Text)
               ] ++ fmap (\x -> "qualifier" .= x) (maybeToList qualifier)


### PR DESCRIPTION
I doubt that you'll want to merge it straight away, but thought I'd still make a PR from my (very modest) changes. The only change is adding support for Implicit having another boolean parameter, indicating whether a module was imported implicitly like this:

    import Prelude

or like this:

    import Prelude (..)

I think for psc-ide it doesn't matter, didn't really add any extra logic. 

This PR won't build as-is, as you'll need to point your stack.yaml file to the purescript src of version 0.8.0.0.

Simon