### PR TITLE
Updated for 0.8.0.0 v2

### DIFF
--- a/psc-ide.cabal
+++ b/psc-ide.cabal
@@ -42,7 +42,7 @@ library
                        , monad-logger
                        , mtl
                        , parsec
-                       , purescript
+                       , purescript >= 0.8.0.0
                        , regex-tdfa
                        , stm
                        , text

--- a/src/PureScript/Ide/Externs.hs
+++ b/src/PureScript/Ide/Externs.hs
@@ -35,7 +35,7 @@ readExternFile fp = do
 moduleNameToText :: N.ModuleName -> T.Text
 moduleNameToText = T.pack . N.runModuleName
 
-properNameToText :: N.ProperName -> T.Text
+properNameToText :: N.ProperName a -> T.Text
 properNameToText = T.pack . N.runProperName
 
 identToText :: N.Ident -> T.Text

--- a/src/PureScript/Ide/SourceFile.hs
+++ b/src/PureScript/Ide/SourceFile.hs
@@ -40,18 +40,18 @@ getImportsForFile fp = do
   module' <- parseModuleFromFile fp
   let imports = getImports <$> module'
   return (fmap (mkModuleImport . unwrapPositionedImport) <$> imports)
-  where mkModuleImport (D.ImportDeclaration mn importType' qualifier) =
+  where mkModuleImport (D.ImportDeclaration mn importType' qualifier _) =
           ModuleImport
             (T.pack (N.runModuleName mn))
             importType'
             (T.pack . N.runModuleName <$> qualifier)
         mkModuleImport _ = error "Shouldn't have gotten anything but Imports here"
-        unwrapPositionedImport (D.ImportDeclaration mn importType' qualifier) =
-          D.ImportDeclaration mn (unwrapImportType importType') qualifier
+        unwrapPositionedImport (D.ImportDeclaration mn importType' qualifier b) =
+          D.ImportDeclaration mn (unwrapImportType importType') qualifier b
         unwrapPositionedImport x = x
         unwrapImportType (D.Explicit decls) = D.Explicit (map unwrapPositionedRef decls)
         unwrapImportType (D.Hiding decls)   = D.Hiding (map unwrapPositionedRef decls)
-        unwrapImportType D.Implicit         = D.Implicit
+        unwrapImportType  D.Implicit        = D.Implicit
 
 getPositionedImports :: D.Module -> [D.Declaration]
 getPositionedImports (D.Module _ _ _ declarations _) =


### PR DESCRIPTION
I think half the changes in https://github.com/kRITZCREEK/psc-ide/pull/97 are still required, the extra boolean on `Import` was removed but that still leaves an extra argument to `ImportDeclaration` vs the current version.

(I couldn't load my externs files generated from `psc` master (https://github.com/purescript/purescript/commit/342c17fb6f1e158481aece274a088ac635262784) before, now I can.)