### PR TITLE
Replace export aliases with import decls.

### DIFF
--- a/src/PureScript/Ide.hs
+++ b/src/PureScript/Ide.hs
@@ -124,7 +124,7 @@ loadReexports m = case getReexports m of
     -- If this ever fails I'll need to look at GADTs
     let reexports = map (\(Export mn) -> mn) exportDeps
     $(logDebug) ("Loading reexports for module: " <> fst m <>
-                 " reexports: " <> T.concat reexports)
+                 " reexports: " <> (T.intercalate ", " reexports))
     traverse_ loadModule reexports
     exportDepsModules <- catMaybes <$> traverse getModule reexports
     exportDepDeps <- traverse loadReexports exportDepsModules
@@ -132,7 +132,7 @@ loadReexports m = case getReexports m of
 
 getDependenciesForModule :: Module -> [ModuleIdent]
 getDependenciesForModule (_, decls) = mapMaybe getDependencyName decls
-  where getDependencyName (Dependency dependencyName _) = Just dependencyName
+  where getDependencyName (Dependency dependencyName _ _) = Just dependencyName
         getDependencyName _ = Nothing
 
 loadModule :: (PscIde m, MonadLogger m, MonadError PscIdeError m) =>

--- a/src/PureScript/Ide/CaseSplit.hs
+++ b/src/PureScript/Ide/CaseSplit.hs
@@ -34,7 +34,7 @@ import           Prelude hiding (lex)
 import           PureScript.Ide.Error
 import           PureScript.Ide.State
 import           PureScript.Ide.Types hiding (Type)
-import           PureScript.Ide.SourceFile (unwrapPositioned)
+import           PureScript.Ide.Externs (unwrapPositioned)
 import           Text.Parsec as P
 
 type Constructor = (ProperName 'ConstructorName, [Type])

--- a/src/PureScript/Ide/Externs.hs
+++ b/src/PureScript/Ide/Externs.hs
@@ -57,10 +57,15 @@ convertExterns ef = (moduleName, exportDecls ++ importDecls ++ otherDecls)
     otherDecls = mapMaybe convertDecl (PE.efDeclarations ef)
 
 convertImport :: PE.ExternsImport -> ExternDecl
-convertImport ei = Dependency (moduleNameToText (PE.eiModule ei)) []
+convertImport ei =
+  Dependency
+  (moduleNameToText (PE.eiModule ei))
+  []
+  (T.pack . N.runModuleName <$> PE.eiImportedAs ei)
 
 convertExport :: D.DeclarationRef -> Maybe ExternDecl
 convertExport (D.ModuleRef mn) = Just (Export (T.pack $ N.runModuleName mn))
+convertExport (D.PositionedDeclarationRef _ _ (D.ModuleRef mn)) = Just (Export (T.pack $ N.runModuleName mn))
 convertExport _ = Nothing
 
 convertDecl :: PE.ExternsDeclaration -> Maybe ExternDecl

--- a/src/PureScript/Ide/Filter.hs
+++ b/src/PureScript/Ide/Filter.hs
@@ -44,7 +44,7 @@ dependencyFilter' moduleIdents mods =
 
     extractDeps :: Module -> [ModuleIdent]
     extractDeps = mapMaybe extractDep . snd
-      where extractDep (Dependency n _) = Just n
+      where extractDep (Dependency n _ _) = Just n
             extractDep (ModuleDecl _ _) = Nothing
             extractDep _ = Nothing
 

--- a/src/PureScript/Ide/SourceFile.hs
+++ b/src/PureScript/Ide/SourceFile.hs
@@ -9,6 +9,7 @@ import qualified Language.PureScript.AST.Declarations as D
 import qualified Language.PureScript.Parser           as P
 import           PureScript.Ide.Error
 import           PureScript.Ide.Types
+import           PureScript.Ide.Externs
 import qualified Language.PureScript.AST.SourcePos    as SP
 import qualified Language.PureScript.Names            as N
 import           System.Directory
@@ -62,14 +63,6 @@ getPositionedImports (D.Module _ _ _ declarations _) =
   where
     isImport i@(D.PositionedDeclaration _ _ (D.ImportDeclaration{})) = Just i
     isImport _ = Nothing
-
-unwrapPositioned :: D.Declaration -> D.Declaration
-unwrapPositioned (D.PositionedDeclaration _ _ x) = x
-unwrapPositioned x = x
-
-unwrapPositionedRef :: D.DeclarationRef -> D.DeclarationRef
-unwrapPositionedRef (D.PositionedDeclarationRef _ _ x) = x
-unwrapPositionedRef x = x
 
 getDeclPosition :: D.Module -> String -> Maybe SP.SourceSpan
 getDeclPosition m ident =

--- a/src/PureScript/Ide/Types.hs
+++ b/src/PureScript/Ide/Types.hs
@@ -31,7 +31,8 @@ data ExternDecl
                         Int
                         DeclIdent
     | Dependency { dependencyModule :: ModuleIdent
-                 , dependencyNames  :: [Text]}
+                 , dependencyNames  :: [Text]
+                 , dependencyAlias  :: Maybe Text }
     | ModuleDecl ModuleIdent
                  [DeclIdent]
     | DataDecl DeclIdent
@@ -43,7 +44,7 @@ instance ToJSON ExternDecl where
   toJSON (FunctionDecl n t)        = object ["name" .= n, "type" .= t]
   toJSON (ModuleDecl   n t)        = object ["name" .= n, "type" .= t]
   toJSON (DataDecl     n t)        = object ["name" .= n, "type" .= t]
-  toJSON (Dependency   n names)    = object ["module" .= n, "names" .= names]
+  toJSON (Dependency   n names _)    = object ["module" .= n, "names" .= names]
   toJSON (FixityDeclaration f p n) = object ["name" .= n
                                             , "fixity" .= show f
                                             , "precedence" .= p]

--- a/test/PureScript/Ide/FilterSpec.hs
+++ b/test/PureScript/Ide/FilterSpec.hs
@@ -11,7 +11,7 @@ modules =
     ("Module.A", [FunctionDecl "function1" ""]),
     ("Module.B", [DataDecl "data1" ""]),
     ("Module.C", [ModuleDecl "Module.C" []]),
-    ("Module.D", [Dependency "Module.C" [], FunctionDecl "asd" ""])
+    ("Module.D", [Dependency "Module.C" [] Nothing, FunctionDecl "asd" ""])
   ]
 
 runEq s = runFilter (equalityFilter s) modules

--- a/test/PureScript/Ide/ReexportsSpec.hs
+++ b/test/PureScript/Ide/ReexportsSpec.hs
@@ -11,6 +11,8 @@ import Control.Exception (evaluate)
 decl1 = FunctionDecl "filter" "asdasd"
 decl2 = DataDecl "Tree" "* -> *"
 decl3 = DataDecl "TreeAsd" "* -> *"
+dep1 = Dependency "Test.Foo" [] (Just "T")
+dep2 = Dependency "Test.Bar" [] (Just "T")
 
 circularModule = ("Circular", [Export "Circular"])
 
@@ -22,6 +24,9 @@ module2 = ("Module2", [decl2])
 
 module3 :: Module
 module3 = ("Module3", [decl3])
+
+module4 :: Module
+module4 = ("Module4", [Export "T", decl1, dep1, dep2])
 
 result :: Module
 result = ("Module1", [decl1, decl2, Export "Module3"])
@@ -58,3 +63,6 @@ spec = do
     it "does not include circular references when replacing reexports" $
       replaceReexports circularModule (uncurry Map.singleton circularModule )
       `shouldBe` ("Circular", [])
+
+    it "replaces exported aliases with imported module" $
+      getReexports module4 `shouldBe` [Export "Test.Foo", Export "Test.Bar"]


### PR DESCRIPTION
This is my first stab at fixing #90 and #118.  It's not perfect but it gets us to a little better state I think. 

One thing I know is a problem with this is that this just picks up the first import alias it finds, so an alias mapped to multiple modules would only import the first one.  Probably an easy fix so I figured I'd try and get any feedback before continuing.  Looking for any suggestions for improvement also as I'm pretty new to Haskell.
